### PR TITLE
Compile fix

### DIFF
--- a/include/linux/bitfield.h
+++ b/include/linux/bitfield.h
@@ -72,7 +72,7 @@
  */
 #define FIELD_FIT(_mask, _val)						\
 	({								\
-		__BF_FIELD_CHECK(_mask, 0ULL, _val, "FIELD_FIT: ");	\
+		__BF_FIELD_CHECK(_mask, 0ULL, 0ULL, "FIELD_FIT: ");	\
 		!((((typeof(_mask))_val) << __bf_shf(_mask)) & ~(_mask)); \
 	})
 


### PR DESCRIPTION
repo current doesnt compile with gcc 11.2.0. added fix from linux repo 

Explanation for fix is in linux commit: [444da3f52407d74c9aa12187ac6b01f76ee47d62](https://github.com/torvalds/linux/commit/444da3f52407d74c9aa12187ac6b01f76ee47d62)
